### PR TITLE
[CIR][NFC] Conform if/else lowering order to match clang's output

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -397,6 +397,11 @@ public:
     return create<cir::MemCpyOp>(loc, dst, src, len);
   }
 
+  cir::SignBitOp createSignBit(mlir::Location loc, mlir::Value val) {
+    auto resTy = cir::IntType::get(getContext(), 32, true);
+    return create<cir::SignBitOp>(loc, resTy, val);
+  }
+
   mlir::Value createSub(mlir::Value lhs, mlir::Value rhs, bool hasNUW = false,
                         bool hasNSW = false) {
     auto op = create<cir::BinOp>(lhs.getLoc(), lhs.getType(),

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1016,6 +1016,9 @@ def VisibilityAttr : CIR_Attr<"Visibility", "visibility"> {
 
   let skipDefaultBuilders = 1;
 
+  // Make DefaultValuedAttr accept VisibilityKind as default value ($0).
+  let constBuilderCall = "cir::VisibilityAttr::get($_builder.getContext(), $0)";
+
   let extraClassDeclaration = [{
     bool isDefault() const { return getValue() == VisibilityKind::Default; };
     bool isHidden() const { return getValue() == VisibilityKind::Hidden; };

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2387,7 +2387,10 @@ def GlobalOp : CIR_Op<"global",
   // TODO: sym_visibility can possibly be represented by implementing the
   // necessary Symbol's interface in terms of linkage instead.
   let arguments = (ins SymbolNameAttr:$sym_name,
-                       VisibilityAttr:$global_visibility,
+                       DefaultValuedAttr<
+                        VisibilityAttr,
+                        "VisibilityKind::Default"
+                       >:$global_visibility,
                        OptionalAttr<StrAttr>:$sym_visibility,
                        TypeAttr:$sym_type,
                        Arg<GlobalLinkageKind, "linkage type">:$linkage,
@@ -2405,7 +2408,7 @@ def GlobalOp : CIR_Op<"global",
   let regions = (region AnyRegion:$ctorRegion, AnyRegion:$dtorRegion);
   let assemblyFormat = [{
        ($sym_visibility^)?
-       custom<OmitDefaultVisibility>($global_visibility)
+       (`` $global_visibility^)?
        (`constant` $constant^)?
        $linkage
        (`comdat` $comdat^)?

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4003,19 +4003,14 @@ def CopyOp : CIR_Op<"copy",
 // MemCpyOp && MemMoveOp
 //===----------------------------------------------------------------------===//
 
-class CIR_MemCpyOp<string mnemonic>: CIR_Op<mnemonic, [AllTypesMatch<["dst", "src"]>]> {
-  let arguments = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
-                       Arg<VoidPtr, "", [MemRead]>:$src,
-                       PrimitiveUInt:$len);
+class CIR_MemOp<string mnemonic>
+    : CIR_Op<mnemonic, [AllTypesMatch<["dst", "src"]>]> {
+  dag commonArgs = (ins Arg<VoidPtr, "", [MemWrite]>:$dst,
+      Arg<VoidPtr, "", [MemRead]>:$src);
   let hasVerifier = 0;
-
-  let extraClassDeclaration = [{
-    /// Returns the byte length type.
-    cir::IntType getLenTy() { return getLen().getType(); }
-  }];
 }
 
-def MemCpyOp : CIR_MemCpyOp<"libc.memcpy"> {
+def MemCpyOp : CIR_MemOp<"libc.memcpy"> {
   let summary = "Equivalent to libc's `memcpy`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memcpy` will copy `len`
@@ -4034,13 +4029,20 @@ def MemCpyOp : CIR_MemCpyOp<"libc.memcpy"> {
     ```
   }];
 
+  let arguments = !con(commonArgs, (ins PrimitiveUInt:$len));
+
   let assemblyFormat = [{
     $len `bytes` `from` $src `to` $dst attr-dict
     `:` type($len) `` `,` qualified(type($src)) `->` qualified(type($dst))
   }];
+
+  let extraClassDeclaration = [{
+    /// Returns the byte length type.
+    cir::IntType getLenTy() { return getLen().getType(); }
+  }];
 }
 
-def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
+def MemMoveOp : CIR_MemOp<"libc.memmove"> {
   let summary = "Equivalent to libc's `memmove`";
   let description = [{
     Given two CIR pointers, `src` and `dst`, `cir.libc.memmove` will copy `len`
@@ -4057,12 +4059,49 @@ def MemMoveOp : CIR_MemCpyOp<"libc.memmove"> {
     ```
   }];
 
+  let arguments = !con(commonArgs, (ins PrimitiveUInt:$len));
 
   let assemblyFormat = [{
     $len `bytes` `from` $src `to` $dst attr-dict
     `:` qualified(type($dst)) `,` type($len)
   }];
+
+  let extraClassDeclaration = [{
+    /// Returns the byte length type.
+    cir::IntType getLenTy() { return getLen().getType(); }
+  }];
 }
+
+//===----------------------------------------------------------------------===//
+// MemCpyInlineOp
+//===----------------------------------------------------------------------===//
+
+def MemCpyInlineOp : CIR_MemOp<"memcpy_inline"> {
+  let summary = "Memory copy with constant length without calling"
+                "any external function";
+  let description = [{
+    Given two CIR pointers, `src` and `dst`, `memcpy_inline` will copy `len`
+    bytes from the memory pointed by `src` to the memory pointed by `dst`.
+
+    Unlike `cir.libc.memcpy`,  this Op guarantees that no external functions 
+    are called, and length of copied bytes is a constant.
+
+    Examples:
+
+    ```mlir
+      // Copying 2 bytes from one array to a struct:
+      cir.memcpy_inline 2 bytes from %arr to %struct : !cir.ptr<!arr> -> !cir.ptr<!struct>
+    ```
+  }];
+
+  let arguments = !con(commonArgs, (ins I64Attr:$len));
+
+  let assemblyFormat = [{
+    $len `bytes` `from` $src `to` $dst attr-dict
+    `:` qualified(type($src)) `->` qualified(type($dst))
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // MemSetOp
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5127,4 +5127,17 @@ def AtomicCmpXchg : CIR_Op<"atomic.cmp_xchg",
   let hasVerifier = 0;
 }
 
+def SignBitOp : CIR_Op<"signbit", [Pure]> {
+  let summary = "Checks the sign of a floating-point number";
+  let description = [{
+    It returns a non-zero value (true) if the number is negative
+    and zero (false) if the number is positive or zero.
+  }];
+  let arguments = (ins CIR_AnyFloat:$input);
+  let results = (outs SInt32:$res);
+  let assemblyFormat = [{
+      $input attr-dict `:` type($input) `->` qualified(type($res))
+  }];
+}
+
 #endif // LLVM_CLANG_CIR_DIALECT_IR_CIROPS

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -750,8 +750,10 @@ def IfOp : CIR_Op<"if",
     }
     ```
 
-    `cir.if` defines no values and the 'else' can be omitted. `cir.yield` must
-    explicitly terminate the region if it has more than one block.
+    `cir.if` defines no values and the 'else' can be omitted. The if/else
+    regions must be terminated. If the region has only one block, the terminator
+    can be left out, and `cir.yield` terminator will be inserted implictly.
+    Otherwise, the region must be explicitly terminated.
   }];
   let arguments = (ins CIR_BoolType:$condition);
   let regions = (region AnyRegion:$thenRegion, AnyRegion:$elseRegion);
@@ -1070,6 +1072,16 @@ def ScopeOp : CIR_Op<"scope", [
     custom<OmittedTerminatorRegion>($scopeRegion) (`:` type($results)^)? attr-dict
   }];
 
+  let extraClassDeclaration = [{
+    /// Determine whether the scope is empty, meaning it contains a single block
+    /// terminated by a cir.yield.
+    bool isEmpty() {
+      auto &entry = getRegion().front();
+      return getRegion().hasOneBlock() &&
+        llvm::isa<YieldOp>(entry.front());
+      }
+    }];
+
   let builders = [
     // Scopes for yielding values.
     OpBuilder<(ins
@@ -1200,7 +1212,7 @@ def ShiftOp : CIR_Op<"shift", [Pure]> {
     be either integer type or vector of integer type. However, they must be
     either all vector of integer type, or all integer type. If they are vectors,
     each vector element of the shift target is shifted by the corresponding
-    shift amount in the shift amount vector. 
+    shift amount in the shift amount vector.
 
     ```mlir
     %7 = cir.shift(left, %1 : !u64i, %4 : !s32i) -> !u64i
@@ -1879,17 +1891,17 @@ def SwitchOp : CIR_Op<"switch",
     is an integral condition value.
 
     The set of `cir.case` operations and their enclosing `cir.switch`
-    represents the semantics of a C/C++ switch statement. Users can use 
+    represents the semantics of a C/C++ switch statement. Users can use
     `collectCases(llvm::SmallVector<CaseOp> &cases)` to collect the `cir.case`
     operation in the `cir.switch` operation easily.
 
     The `cir.case` operations doesn't have to be in the region of `cir.switch`
     directly. However, when all the `cir.case` operations lives in the region
     of `cir.switch` directly and there is no other operations except the ending
-    `cir.yield` operation in the region of `cir.switch` directly, we call the 
-    `cir.switch` operation is in a simple form. Users can use 
+    `cir.yield` operation in the region of `cir.switch` directly, we call the
+    `cir.switch` operation is in a simple form. Users can use
     `bool isSimpleForm(llvm::SmallVector<CaseOp> &cases)` member function to
-    detect if the `cir.switch` operation is in a simple form. The simple form 
+    detect if the `cir.switch` operation is in a simple form. The simple form
     makes analysis easier to handle the `cir.switch` operation
     and makes the boundary to give up pretty clear.
 
@@ -1976,7 +1988,7 @@ def SwitchOp : CIR_Op<"switch",
     switch(int cond) {
       l:
         b++;
-  
+
       case 4:
         a++;
         break;
@@ -4178,13 +4190,13 @@ def ReturnAddrOp : CIR_Op<"return_address"> {
   let results = (outs Res<VoidPtr, "">:$result);
 
   let description = [{
-    Represents call to builtin function ` __builtin_return_address` in CIR. 
-    This builtin function returns the return address of the current function, 
-    or of one of its callers. 
+    Represents call to builtin function ` __builtin_return_address` in CIR.
+    This builtin function returns the return address of the current function,
+    or of one of its callers.
     The `level` argument is number of frames to scan up the call stack.
-    For instance, value of 0 yields the return address of the current function, 
-    value of 1 yields the return address of the caller of the current function, 
-    and so forth. 
+    For instance, value of 0 yields the return address of the current function,
+    value of 1 yields the return address of the caller of the current function,
+    and so forth.
 
     Examples:
 
@@ -4324,8 +4336,8 @@ def AbsOp : CIR_Op<"abs", [Pure, SameOperandsAndResultType]> {
   let summary = [{
     libc builtin equivalent abs, labs, llabs
 
-    The `poison` argument indicate whether the result value 
-    is a poison value if the first argument is statically or 
+    The `poison` argument indicate whether the result value
+    is a poison value if the first argument is statically or
     dynamically an INT_MIN value.
 
     Example:

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -229,6 +229,7 @@ struct MissingFeatures {
   static bool emitConstrainedFPCall() { return false; }
   static bool emitEmptyRecordCheck() { return false; }
   static bool isPPC_FP128Ty() { return false; }
+  static bool emitBinaryAtomicPostHasInvert() { return false; }
 
   // Inline assembly
   static bool asmGoto() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -228,6 +228,7 @@ struct MissingFeatures {
   static bool xray() { return false; }
   static bool emitConstrainedFPCall() { return false; }
   static bool emitEmptyRecordCheck() { return false; }
+  static bool isPPC_FP128Ty() { return false; }
 
   // Inline assembly
   static bool asmGoto() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -68,7 +68,6 @@ struct MissingFeatures {
 
   // Address space related
   static bool addressSpace() { return false; }
-  static bool addressSpaceInGlobalVar() { return false; }
 
   // Clang codegen options
   static bool strictVTablePointers() { return false; }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -285,19 +285,6 @@ static void printOmittedTerminatorRegion(mlir::OpAsmPrinter &printer,
                       /*printBlockTerminators=*/!omitRegionTerm(region));
 }
 
-static mlir::ParseResult
-parseOmitDefaultVisibility(mlir::OpAsmParser &parser,
-                           cir::VisibilityAttr &visibility) {
-  parseVisibilityAttr(parser, visibility);
-  return success();
-}
-
-static void printOmitDefaultVisibility(mlir::OpAsmPrinter &printer,
-                                       cir::GlobalOp &op,
-                                       cir::VisibilityAttr visibility) {
-  printVisibilityAttr(printer, visibility);
-}
-
 //===----------------------------------------------------------------------===//
 // AllocaOp
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -60,9 +60,9 @@ struct RemoveEmptyScope : public OpRewritePattern<ScopeOp> {
   using OpRewritePattern<ScopeOp>::OpRewritePattern;
 
   LogicalResult match(ScopeOp op) const final {
-    return success(op.getRegion().empty() ||
-                   (op.getRegion().getBlocks().size() == 1 &&
-                    op.getRegion().front().empty()));
+    // TODO: Remove this logic once CIR uses MLIR infrastructure to remove
+    // trivially dead operations
+    return success(op.isEmpty());
   }
 
   void rewrite(ScopeOp op, PatternRewriter &rewriter) const final {

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -91,7 +91,7 @@ struct CIRIfFlattening : public OpRewritePattern<IfOp> {
     if (!emptyElse) {
       elseBeforeBody = &ifOp.getElseRegion().front();
       elseAfterBody = &ifOp.getElseRegion().back();
-      rewriter.inlineRegionBefore(ifOp.getElseRegion(), thenAfterBody);
+      rewriter.inlineRegionBefore(ifOp.getElseRegion(), continueBlock);
     } else {
       elseBeforeBody = elseAfterBody = continueBlock;
     }

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -66,7 +66,7 @@ struct CIRIfFlattening : public OpRewritePattern<IfOp> {
     auto *remainingOpsBlock =
         rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
     mlir::Block *continueBlock;
-    if (ifOp->getResults().size() == 0)
+    if (ifOp->getResults().empty())
       continueBlock = remainingOpsBlock;
     else
       llvm_unreachable("NYI");
@@ -125,7 +125,9 @@ public:
     auto loc = scopeOp.getLoc();
 
     // Empty scope: just remove it.
-    if (scopeOp.getRegion().empty()) {
+    // TODO: Remove this logic once CIR uses MLIR infrastructure to remove
+    // trivially dead operations
+    if (scopeOp.isEmpty()) {
       rewriter.eraseOp(scopeOp);
       return mlir::success();
     }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -778,6 +778,21 @@ public:
   }
 };
 
+class CIRMemCpyInlineOpLowering
+    : public mlir::OpConversionPattern<cir::MemCpyInlineOp> {
+public:
+  using mlir::OpConversionPattern<cir::MemCpyInlineOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::MemCpyInlineOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::MemcpyInlineOp>(
+        op, adaptor.getDst(), adaptor.getSrc(), adaptor.getLenAttr(),
+        /*isVolatile=*/false);
+    return mlir::success();
+  }
+};
+
 class CIRMemMoveOpLowering : public mlir::OpConversionPattern<cir::MemMoveOp> {
 public:
   using mlir::OpConversionPattern<cir::MemMoveOp>::OpConversionPattern;
@@ -4362,8 +4377,8 @@ void populateCIRToLLVMConversionPatterns(
       CIRVAStartLowering, CIRVAEndLowering, CIRVACopyLowering, CIRVAArgLowering,
       CIRBrOpLowering, CIRGetMemberOpLowering, CIRGetRuntimeMemberOpLowering,
       CIRSwitchFlatOpLowering, CIRPtrDiffOpLowering, CIRCopyOpLowering,
-      CIRMemCpyOpLowering, CIRMemChrOpLowering, CIRFAbsOpLowering,
-      CIRExpectOpLowering, CIRVTableAddrPointOpLowering,
+      CIRMemCpyOpLowering, CIRMemChrOpLowering, CIRMemCpyInlineOpLowering,
+      CIRFAbsOpLowering, CIRExpectOpLowering, CIRVTableAddrPointOpLowering,
       CIRVectorCreateLowering, CIRVectorCmpOpLowering, CIRVectorSplatLowering,
       CIRVectorTernaryLowering, CIRVectorShuffleIntsLowering,
       CIRVectorShuffleVecLowering, CIRStackSaveLowering, CIRUnreachableLowering,
@@ -4407,27 +4422,27 @@ std::unique_ptr<cir::LowerModule> prepareLowerModule(mlir::ModuleOp module) {
 void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
                           mlir::DataLayout &dataLayout,
                           cir::LowerModule *lowerModule) {
-  converter.addConversion([&,
-                           lowerModule](cir::PointerType type) -> mlir::Type {
-    // Drop pointee type since LLVM dialect only allows opaque pointers.
+  converter.addConversion(
+      [&, lowerModule](cir::PointerType type) -> mlir::Type {
+        // Drop pointee type since LLVM dialect only allows opaque pointers.
 
-    auto addrSpace =
-        mlir::cast_if_present<cir::AddressSpaceAttr>(type.getAddrSpace());
-    // Null addrspace attribute indicates the default addrspace.
-    if (!addrSpace)
-      return mlir::LLVM::LLVMPointerType::get(type.getContext());
+        auto addrSpace =
+            mlir::cast_if_present<cir::AddressSpaceAttr>(type.getAddrSpace());
+        // Null addrspace attribute indicates the default addrspace.
+        if (!addrSpace)
+          return mlir::LLVM::LLVMPointerType::get(type.getContext());
 
-    assert(lowerModule && "CIR AS map is not available");
-    // Pass through target addrspace and map CIR addrspace to LLVM addrspace by
-    // querying the target info.
-    unsigned targetAS =
-        addrSpace.isTarget()
-            ? addrSpace.getTargetValue()
-            : lowerModule->getTargetLoweringInfo()
-                  .getTargetAddrSpaceFromCIRAddrSpace(addrSpace);
+        assert(lowerModule && "CIR AS map is not available");
+        // Pass through target addrspace and map CIR addrspace to LLVM addrspace
+        // by querying the target info.
+        unsigned targetAS =
+            addrSpace.isTarget()
+                ? addrSpace.getTargetValue()
+                : lowerModule->getTargetLoweringInfo()
+                      .getTargetAddrSpaceFromCIRAddrSpace(addrSpace);
 
-    return mlir::LLVM::LLVMPointerType::get(type.getContext(), targetAS);
-  });
+        return mlir::LLVM::LLVMPointerType::get(type.getContext(), targetAS);
+      });
   converter.addConversion([&](cir::DataMemberType type) -> mlir::Type {
     return mlir::IntegerType::get(type.getContext(),
                                   dataLayout.getTypeSizeInBits(type));

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4304,6 +4304,37 @@ public:
     return mlir::success();
   }
 };
+class CIRSignBitOpLowering : public mlir::OpConversionPattern<cir::SignBitOp> {
+public:
+  using OpConversionPattern<cir::SignBitOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::SignBitOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    assert(!::cir::MissingFeatures::isPPC_FP128Ty());
+
+    mlir::DataLayout layout(op->getParentOfType<mlir::ModuleOp>());
+    int width = layout.getTypeSizeInBits(op.getInput().getType());
+    if (auto longDoubleType =
+            mlir::dyn_cast<cir::LongDoubleType>(op.getInput().getType())) {
+      if (mlir::isa<cir::FP80Type>(longDoubleType.getUnderlying())) {
+        // see https://github.com/llvm/clangir/issues/1057
+        llvm_unreachable("NYI");
+      }
+    }
+    auto intTy = mlir::IntegerType::get(rewriter.getContext(), width);
+    auto bitcast = rewriter.create<mlir::LLVM::BitcastOp>(op->getLoc(), intTy,
+                                                          adaptor.getInput());
+    auto zero = rewriter.create<mlir::LLVM::ConstantOp>(op->getLoc(), intTy, 0);
+    auto cmpResult = rewriter.create<mlir::LLVM::ICmpOp>(
+        op.getLoc(), mlir::LLVM::ICmpPredicate::slt, bitcast.getResult(), zero);
+    auto converted = rewriter.create<mlir::LLVM::ZExtOp>(
+        op.getLoc(), mlir::IntegerType::get(rewriter.getContext(), 32),
+        cmpResult);
+    rewriter.replaceOp(op, converted);
+    return mlir::success();
+  }
+};
 
 void populateCIRToLLVMConversionPatterns(
     mlir::RewritePatternSet &patterns, mlir::TypeConverter &converter,
@@ -4352,7 +4383,7 @@ void populateCIRToLLVMConversionPatterns(
       CIRAssumeLowering, CIRAssumeAlignedLowering, CIRAssumeSepStorageLowering,
       CIRBaseClassAddrOpLowering, CIRDerivedClassAddrOpLowering,
       CIRVTTAddrPointOpLowering, CIRIsFPClassOpLowering, CIRAbsOpLowering,
-      CIRMemMoveOpLowering, CIRMemsetOpLowering
+      CIRMemMoveOpLowering, CIRMemsetOpLowering, CIRSignBitOpLowering
 #define GET_BUILTIN_LOWERING_LIST
 #include "clang/CIR/Dialect/IR/CIRBuiltinsLowering.inc"
 #undef GET_BUILTIN_LOWERING_LIST

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -787,7 +787,9 @@ class CIRScopeOpLowering : public mlir::OpConversionPattern<cir::ScopeOp> {
   matchAndRewrite(cir::ScopeOp scopeOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // Empty scope: just remove it.
-    if (scopeOp.getRegion().empty()) {
+    // TODO: Remove this logic once CIR uses MLIR infrastructure to remove
+    // trivially dead operations
+    if (scopeOp.isEmpty()) {
       rewriter.eraseOp(scopeOp);
       return mlir::success();
     }

--- a/clang/test/CIR/CallConvLowering/AArch64/struct.c
+++ b/clang/test/CIR/CallConvLowering/AArch64/struct.c
@@ -40,7 +40,7 @@ S init(S s) {
   return s;
 }
 
-// CIR: cir.func no_proto  @foo1
+// CIR: cir.func no_proto @foo1
 // CIR: %[[#V0:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["s"]
 // CIR: %[[#V1:]] = cir.alloca !ty_S, !cir.ptr<!ty_S>, ["tmp"] {alignment = 4 : i64}
 // CIR: %[[#V2:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S>), !cir.ptr<!u64i>
@@ -143,7 +143,7 @@ S2 init2(S2 s) {
   return s;
 }
 
-// CIR: cir.func no_proto  @foo3()
+// CIR: cir.func no_proto @foo3()
 // CIR: %[[#V0:]] = cir.alloca !ty_S2_, !cir.ptr<!ty_S2_>, ["s"]
 // CIR: %[[#V1:]] = cir.alloca !ty_S2_, !cir.ptr<!ty_S2_>, ["tmp"] {alignment = 1 : i64}
 // CIR: %[[#V2:]] = cir.cast(bitcast, %[[#V0]] : !cir.ptr<!ty_S2_>), !cir.ptr<!u16i>

--- a/clang/test/CIR/CodeGen/AArch64/neon-arith.c
+++ b/clang/test/CIR/CodeGen/AArch64/neon-arith.c
@@ -20,7 +20,7 @@
 float32_t test_vrndns_f32(float32_t a) {
   return vrndns_f32(a);
 }
-// CIR: cir.func internal private  @vrndns_f32(%arg0: !cir.float {{.*}}) -> !cir.float
+// CIR: cir.func internal private @vrndns_f32(%arg0: !cir.float {{.*}}) -> !cir.float
 // CIR: cir.store %arg0, [[ARG_SAVE:%.*]] : !cir.float, !cir.ptr<!cir.float> 
 // CIR: [[INTRIN_ARG:%.*]] = cir.load [[ARG_SAVE]] : !cir.ptr<!cir.float>, !cir.float 
 // CIR: {{%.*}} = cir.llvm.intrinsic "roundeven.f32" [[INTRIN_ARG]] : (!cir.float)
@@ -42,7 +42,7 @@ float32x2_t test_vrnda_f32(float32x2_t a) {
   return vrnda_f32(a);
 }
 
-// CIR: cir.func internal private  @vrnda_f32(%arg0: !cir.vector<!cir.float x 2>
+// CIR: cir.func internal private @vrnda_f32(%arg0: !cir.vector<!cir.float x 2>
 // CIR: cir.store %arg0, [[ARG_SAVE:%.*]] : !cir.vector<!cir.float x 2>, !cir.ptr<!cir.vector<!cir.float x 2>>
 // CIR: [[INTRIN_ARG:%.*]] = cir.load [[ARG_SAVE]] : !cir.ptr<!cir.vector<!cir.float x 2>>, !cir.vector<!cir.float x 2>
 // CIR: [[INTRIN_ARG_CAST:%.*]] = cir.cast(bitcast, [[INTRIN_ARG]] : !cir.vector<!cir.float x 2>), !cir.vector<!s8i x 8>
@@ -66,7 +66,7 @@ float32x4_t test_vrndaq_f32(float32x4_t a) {
   return vrndaq_f32(a);
 }
 
-// CIR: cir.func internal private  @vrndaq_f32(%arg0: !cir.vector<!cir.float x 4>
+// CIR: cir.func internal private @vrndaq_f32(%arg0: !cir.vector<!cir.float x 4>
 // CIR: cir.store %arg0, [[ARG_SAVE:%.*]] : !cir.vector<!cir.float x 4>, !cir.ptr<!cir.vector<!cir.float x 4>>
 // CIR: [[INTRIN_ARG:%.*]] = cir.load [[ARG_SAVE]] : !cir.ptr<!cir.vector<!cir.float x 4>>, !cir.vector<!cir.float x 4>
 // CIR: [[INTRIN_ARG_CAST:%.*]] = cir.cast(bitcast, [[INTRIN_ARG]] : !cir.vector<!cir.float x 4>), !cir.vector<!s8i x 16>

--- a/clang/test/CIR/CodeGen/OpenMP/parallel.cpp
+++ b/clang/test/CIR/CodeGen/OpenMP/parallel.cpp
@@ -4,8 +4,6 @@
 // CHECK: cir.func
 void omp_parallel_1() {
 // CHECK: omp.parallel {
-// CHECK-NEXT: cir.scope {
-// CHECK-NEXT: }
 // CHECK-NEXT: omp.terminator
 // CHECK-NEXT: }
 #pragma omp parallel

--- a/clang/test/CIR/CodeGen/abstract-cond.c
+++ b/clang/test/CIR/CodeGen/abstract-cond.c
@@ -27,10 +27,10 @@ int f6(int a0, struct s6 a1, struct s6 a2) {
 // LLVM:    %[[LOAD_A0:.*]] = load i32, ptr {{.*}}
 // LLVM:    %[[COND:.*]] = icmp ne i32 %[[LOAD_A0]], 0
 // LLVM:    br i1 %[[COND]], label %[[A1_PATH:.*]], label %[[A2_PATH:.*]],
-// LLVM:  [[A2_PATH]]:
+// LLVM:  [[A1_PATH]]:
 // LLVM:    call void @llvm.memcpy.p0.p0.i32(ptr %[[TMP:.*]], ptr {{.*}}, i32 4, i1 false)
 // LLVM:    br label %[[EXIT:[a-z0-9]+]]
-// LLVM:  [[A1_PATH]]:
+// LLVM:  [[A2_PATH]]:
 // LLVM:    call void @llvm.memcpy.p0.p0.i32(ptr %[[TMP]], ptr {{.*}}, i32 4, i1 false)
 // LLVM:    br label %[[EXIT]]
 // LLVM:  [[EXIT]]:

--- a/clang/test/CIR/CodeGen/annotations-var.c
+++ b/clang/test/CIR/CodeGen/annotations-var.c
@@ -3,8 +3,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-android21 -fclangir -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
-// CIR-DAG:  cir.global  external @globalvar = #cir.int<3> : !s32i [#cir.annotation<name = "globalvar_ann_0", args = []>] {alignment = 4 : i64}
-// CIR-DAG:  cir.global  external @globalvar2 = #cir.int<2> : !s32i [#cir.annotation<name = "common_ann", args = ["os", 21 : i32]>] {alignment = 4 : i64}
+// CIR-DAG:  cir.global external @globalvar = #cir.int<3> : !s32i [#cir.annotation<name = "globalvar_ann_0", args = []>] {alignment = 4 : i64}
+// CIR-DAG:  cir.global external @globalvar2 = #cir.int<2> : !s32i [#cir.annotation<name = "common_ann", args = ["os", 21 : i32]>] {alignment = 4 : i64}
 
 // LLVM-DAG: @.str.annotation = private unnamed_addr constant [15 x i8] c"localvar_ann_0\00", section "llvm.metadata"
 // LLVM-DAG: @.str.1.annotation = private unnamed_addr constant [{{[0-9]+}} x i8] c"{{.*}}annotations-var.c\00", section "llvm.metadata"

--- a/clang/test/CIR/CodeGen/array-init.c
+++ b/clang/test/CIR/CodeGen/array-init.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o - | FileCheck %s
 
-// CHECK-DAG: cir.global "private"  constant cir_private @__const.foo.bar = #cir.const_array<[#cir.fp<9.000000e+00> : !cir.double, #cir.fp<8.000000e+00> : !cir.double, #cir.fp<7.000000e+00> : !cir.double]> : !cir.array<!cir.double x 3>
+// CHECK-DAG: cir.global "private" constant cir_private @__const.foo.bar = #cir.const_array<[#cir.fp<9.000000e+00> : !cir.double, #cir.fp<8.000000e+00> : !cir.double, #cir.fp<7.000000e+00> : !cir.double]> : !cir.array<!cir.double x 3>
 typedef struct {
   int a;
   long b;

--- a/clang/test/CIR/CodeGen/atomic.cpp
+++ b/clang/test/CIR/CodeGen/atomic.cpp
@@ -12,6 +12,15 @@ typedef struct _a {
 
 void m() { at y; }
 
+signed char sc;
+unsigned char uc;
+signed short ss;
+unsigned short us;
+signed int si;
+unsigned int ui;
+signed long long sll;
+unsigned long long ull;
+
 // CHECK: ![[A:.*]] = !cir.struct<struct "_a" {!s32i}>
 
 int basic_binop_fetch(int *i) {
@@ -648,4 +657,86 @@ void cmp_val_ushort(unsigned short* p, short x, short u) {
 // LLVM: cmpxchg ptr {{.*}}, i64 {{.*}}, i64 {{.*}} seq_cst seq_cst
 void cmp_val_ulong(unsigned long* p, long x, long u) {
   long r = __sync_val_compare_and_swap(p, x, u);
+}
+
+// CHECK-LABEL: @test_op_and_fetch
+// LLVM-LABEL: @test_op_and_fetch
+extern "C" void test_op_and_fetch (void)
+{
+  // CHECK: [[VAL0:%.*]] = cir.cast(integral, {{%.*}} : !u8i), !s8i
+  // CHECK: [[RES0:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!s8i>, [[VAL0]] : !s8i, seq_cst) fetch_first : !s8i
+  // CHECK: [[RET0:%.*]] = cir.binop(add, [[RES0]], [[VAL0]]) : !s8i
+  // LLVM:  [[VAL0:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[RES0:%.*]] = atomicrmw add ptr @sc, i8 [[VAL0]] seq_cst, align 1
+  // LLVM:  [[RET0:%.*]] = add i8 [[RES0]], [[VAL0]]
+  // LLVM:  store i8 [[RET0]], ptr @sc, align 1
+  sc = __sync_add_and_fetch (&sc, uc); 
+
+  // CHECK: [[RES1:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!u8i>, [[VAL1:%.*]] : !u8i, seq_cst) fetch_first : !u8i
+  // CHECK: [[RET1:%.*]] = cir.binop(add, [[RES1]], [[VAL1]]) : !u8i
+  // LLVM:  [[VAL1:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[RES1:%.*]] = atomicrmw add ptr @uc, i8 [[VAL1]] seq_cst, align 1
+  // LLVM:  [[RET1:%.*]] = add i8 [[RES1]], [[VAL1]]
+  // LLVM:  store i8 [[RET1]], ptr @uc, align 1
+  uc = __sync_add_and_fetch (&uc, uc); 
+  
+  // CHECK: [[VAL2:%.*]] = cir.cast(integral, {{%.*}} : !u8i), !s16i
+  // CHECK: [[RES2:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!s16i>, [[VAL2]] : !s16i, seq_cst) fetch_first : !s16i
+  // CHECK: [[RET2:%.*]] = cir.binop(add, [[RES2]], [[VAL2]]) : !s16i
+  // LLVM:  [[VAL2:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[CONV2:%.*]] = zext i8 [[VAL2]] to i16
+  // LLVM:  [[RES2:%.*]] = atomicrmw add ptr @ss, i16 [[CONV2]] seq_cst, align 2
+  // LLVM:  [[RET2:%.*]] = add i16 [[RES2]], [[CONV2]]
+  // LLVM:  store i16 [[RET2]], ptr @ss, align 2
+  ss = __sync_add_and_fetch (&ss, uc); 
+
+  // CHECK: [[VAL3:%.*]] = cir.cast(integral, {{%.*}} : !u8i), !u16i
+  // CHECK: [[RES3:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!u16i>, [[VAL3]] : !u16i, seq_cst) fetch_first : !u16i
+  // CHECK: [[RET3:%.*]] = cir.binop(add, [[RES3]], [[VAL3]]) : !u16i
+  // LLVM:  [[VAL3:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[CONV3:%.*]] = zext i8 [[VAL3]] to i16
+  // LLVM:  [[RES3:%.*]] = atomicrmw add ptr @us, i16 [[CONV3]] seq_cst, align 2
+  // LLVM:  [[RET3:%.*]] = add i16 [[RES3]], [[CONV3]]
+  // LLVM:  store i16 [[RET3]], ptr @us
+  us = __sync_add_and_fetch (&us, uc); 
+
+  // CHECK: [[VAL4:%.*]] = cir.cast(integral, {{%.*}} : !u8i), !s32i
+  // CHECK: [[RES4:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!s32i>, [[VAL4]] : !s32i, seq_cst) fetch_first : !s32i
+  // CHECK: [[RET4:%.*]] = cir.binop(add, [[RES4]], [[VAL4]]) : !s32i
+  // LLVM:  [[VAL4:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[CONV4:%.*]] = zext i8 [[VAL4]] to i32
+  // LLVM:  [[RES4:%.*]] = atomicrmw add ptr @si, i32 [[CONV4]] seq_cst, align 4
+  // LLVM:  [[RET4:%.*]] = add i32 [[RES4]], [[CONV4]]
+  // LLVM:  store i32 [[RET4]], ptr @si, align 4
+  si = __sync_add_and_fetch (&si, uc); 
+
+  // CHECK: [[VAL5:%.*]] = cir.cast(integral, {{%.*}} : !u8i), !u32i
+  // CHECK: [[RES5:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!u32i>, [[VAL5]] : !u32i, seq_cst) fetch_first : !u32i
+  // CHECK: [[RET5:%.*]] = cir.binop(add, [[RES5]], [[VAL5]]) : !u32i
+  // LLVM:  [[VAL5:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[CONV5:%.*]] = zext i8 [[VAL5]] to i32
+  // LLVM:  [[RES5:%.*]] = atomicrmw add ptr @ui, i32 [[CONV5]] seq_cst, align 4
+  // LLVM:  [[RET5:%.*]] = add i32 [[RES5]], [[CONV5]]
+  // LLVM:  store i32 [[RET5]], ptr @ui, align 4
+  ui = __sync_add_and_fetch (&ui, uc); 
+
+  // CHECK: [[VAL6:%.*]] = cir.cast(integral, {{%.*}} : !u8i), !s64i
+  // CHECK: [[RES6:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!s64i>, [[VAL6]] : !s64i, seq_cst) fetch_first : !s64i
+  // CHECK: [[RET6:%.*]] = cir.binop(add, [[RES6]], [[VAL6]]) : !s64i
+  // LLVM:  [[VAL6:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[CONV6:%.*]] = zext i8 [[VAL6]] to i64
+  // LLVM:  [[RES6:%.*]] = atomicrmw add ptr @sll, i64 [[CONV6]] seq_cst, align 8
+  // LLVM:  [[RET6:%.*]] = add i64 [[RES6]], [[CONV6]]
+  // LLVM:  store i64 [[RET6]], ptr @sll, align 8
+  sll = __sync_add_and_fetch (&sll, uc); 
+
+  // CHECK: [[VAL7:%.*]] = cir.cast(integral, {{%.*}} : !u8i), !u64i
+  // CHECK: [[RES7:%.*]] = cir.atomic.fetch(add, {{%.*}} : !cir.ptr<!u64i>, [[VAL7]] : !u64i, seq_cst) fetch_first : !u64i
+  // CHECK: [[RET7:%.*]] = cir.binop(add, [[RES7]], [[VAL7]]) : !u64i
+  // LLVM:  [[VAL7:%.*]] = load i8, ptr @uc, align 1
+  // LLVM:  [[CONV7:%.*]] = zext i8 [[VAL7]] to i64
+  // LLVM:  [[RES7:%.*]] = atomicrmw add ptr @ull, i64 [[CONV7]] seq_cst, align 8
+  // LLVM:  [[RET7:%.*]] = add i64 [[RES7]], [[CONV7]]
+  // LLVM:  store i64 [[RET7]], ptr @ull, align 8
+  ull = __sync_add_and_fetch (&ull, uc); 
 }

--- a/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
+++ b/clang/test/CIR/CodeGen/attribute-annotate-multiple.cpp
@@ -18,11 +18,11 @@ void bar() __attribute__((annotate("withargfunc", "os", 22))) {
 
 // BEFORE: module @{{.*}}attribute-annotate-multiple.cpp" attributes {cir.lang =
 
-// BEFORE: cir.global  external @a = #cir.ptr<null> : !cir.ptr<!cir.double>
+// BEFORE: cir.global external @a = #cir.ptr<null> : !cir.ptr<!cir.double>
 // BEFORE-SAME: [#cir.annotation<name = "withargs", args = ["21", 12 : i32]>]
-// BEFORE: cir.global  external @b = #cir.ptr<null> : !cir.ptr<!s32i>
+// BEFORE: cir.global external @b = #cir.ptr<null> : !cir.ptr<!s32i>
 // BEFORE-SAME: [#cir.annotation<name = "withargs", args = ["21", 12 : i32]>]
-// BEFORE: cir.global  external @c = #cir.ptr<null> : !cir.ptr<!void>
+// BEFORE: cir.global external @c = #cir.ptr<null> : !cir.ptr<!void>
 // BEFORE-SAME: [#cir.annotation<name = "noargvar", args = []>]
 // BEFORE: cir.global external @tile = #cir.int<7> : !s32i
 // BEFORE-SAME: #cir.annotation<name = "cir.aie.device.tile", args = [42 : i8]>]

--- a/clang/test/CIR/CodeGen/builtin-signbit.c
+++ b/clang/test/CIR/CodeGen/builtin-signbit.c
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+void test_signbit_float(float val) {
+    // CIR-LABEL: test_signbit_float
+    // CIR: %{{.+}} = cir.signbit %{{.+}} : !cir.float -> !s32i
+    // LLVM-LABEL: test_signbit_float
+    // LLVM: [[TMP1:%.*]] = bitcast float %{{.+}} to i32
+    // LLVM: [[TMP2:%.*]] = icmp slt i32 [[TMP1]], 0
+    // LLVM: %{{.+}} = zext i1 [[TMP2]] to i32
+    __builtin_signbit(val);
+}
+
+void test_signbit_double(double val) {
+    // CIR-LABEL: test_signbit_double
+    // CIR: %{{.+}} = cir.signbit %{{.+}} : !cir.float -> !s32i
+    // LLVM-LABEL: test_signbit_double
+    // LLVM: [[CONV:%.*]] = fptrunc double %{{.+}} to float
+    // LLVM: [[TMP1:%.*]] = bitcast float [[CONV]] to i32
+    // LLVM: [[TMP2:%.*]] = icmp slt i32 [[TMP1]], 0
+    // LLVM: %{{.+}} = zext i1 [[TMP2]] to i32
+    __builtin_signbitf(val);
+}

--- a/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
+++ b/clang/test/CIR/CodeGen/cxx1z-inline-variables.cpp
@@ -26,13 +26,13 @@ const int &compat_use_after_redecl1 = compat::c;
 const int &compat_use_after_redecl2 = compat::d;
 const int &compat_use_after_redecl3 = compat::g;
 
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1bE = #cir.int<2> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1aE = #cir.int<1> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1cE = #cir.int<3> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant external @_ZN6compat1eE = #cir.int<5> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant weak_odr comdat @_ZN6compat1fE = #cir.int<6> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant linkonce_odr comdat @_ZN6compat1dE = #cir.int<4> : !s32i {alignment = 4 : i64}
-// CIR: cir.global  constant linkonce_odr comdat @_ZN6compat1gE = #cir.int<7> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1bE = #cir.int<2> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1aE = #cir.int<1> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1cE = #cir.int<3> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant external @_ZN6compat1eE = #cir.int<5> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant weak_odr comdat @_ZN6compat1fE = #cir.int<6> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant linkonce_odr comdat @_ZN6compat1dE = #cir.int<4> : !s32i {alignment = 4 : i64}
+// CIR: cir.global constant linkonce_odr comdat @_ZN6compat1gE = #cir.int<7> : !s32i {alignment = 4 : i64}
 
 // LLVM: $_ZN6compat1bE = comdat any
 // LLVM: $_ZN6compat1aE = comdat any

--- a/clang/test/CIR/CodeGen/global-new.cpp
+++ b/clang/test/CIR/CodeGen/global-new.cpp
@@ -14,7 +14,7 @@ e *g = new e(0);
 
 // CIR_BEFORE: ![[ty:.*]] = !cir.struct<struct "e" {!u8i}
 
-// CIR_BEFORE: cir.global  external @g = ctor : !cir.ptr<![[ty]]> {
+// CIR_BEFORE: cir.global external @g = ctor : !cir.ptr<![[ty]]> {
 // CIR_BEFORE:     %[[GlobalAddr:.*]] = cir.get_global @g : !cir.ptr<!cir.ptr<![[ty]]>>
 // CIR_BEFORE:     %[[Size:.*]] = cir.const #cir.int<1> : !u64i
 // CIR_BEFORE:     %[[NewAlloc:.*]] = cir.call @_Znwm(%[[Size]]) : (!u64i) -> !cir.ptr<!void>
@@ -37,7 +37,7 @@ e *g = new e(0);
 // CIR_EH:   cir.resume
 // CIR_EH: }]
 
-// CIR_FLAT_EH: cir.func internal private  @__cxx_global_var_init()
+// CIR_FLAT_EH: cir.func internal private @__cxx_global_var_init()
 // CIR_FLAT_EH: ^bb3:
 // CIR_FLAT_EH:   %exception_ptr, %type_id = cir.eh.inflight_exception
 // CIR_FLAT_EH:   cir.call @_ZdlPvm({{.*}}) : (!cir.ptr<!void>, !u64i) -> ()

--- a/clang/test/CIR/CodeGen/globals-neg-index-array.c
+++ b/clang/test/CIR/CodeGen/globals-neg-index-array.c
@@ -14,7 +14,7 @@ struct __attribute__((packed)) PackedStruct {
 };
 struct PackedStruct packed[10];
 char *packed_element = &(packed[-2].a3);
-// CHECK: cir.global  external @packed = #cir.zero : !cir.array<!ty_PackedStruct x 10> {alignment = 16 : i64} loc(#loc5)
-// CHECK: cir.global  external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
+// CHECK: cir.global external @packed = #cir.zero : !cir.array<!ty_PackedStruct x 10> {alignment = 16 : i64} loc(#loc5)
+// CHECK: cir.global external @packed_element = #cir.global_view<@packed, [-2 : i32, 2 : i32]>
 // LLVM: @packed = global [10 x %struct.PackedStruct] zeroinitializer
 // LLVM: @packed_element = global ptr getelementptr inbounds ([10 x %struct.PackedStruct], ptr @packed, i32 0, i32 -2, i32 2)

--- a/clang/test/CIR/CodeGen/if-constexpr.cpp
+++ b/clang/test/CIR/CodeGen/if-constexpr.cpp
@@ -75,9 +75,6 @@ void if0() {
 // CHECK-NEXT:   cir.store %3, %2 : !s32i, !cir.ptr<!s32i> loc({{.*}})
 // CHECK-NEXT: } loc({{.*}})
 // CHECK-NEXT: cir.scope {
-// Note that Clang does not even emit a block in this case
-// CHECK-NEXT: } loc({{.*}})
-// CHECK-NEXT: cir.scope {
 // CHECK-NEXT:   %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {{.*}}
 // CHECK-NEXT:   %3 = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init] {{.*}}
 // CHECK-NEXT:   %4 = cir.const #cir.int<70> : !s32i loc({{.*}})

--- a/clang/test/CIR/CodeGen/kr-func-promote.c
+++ b/clang/test/CIR/CodeGen/kr-func-promote.c
@@ -6,7 +6,7 @@
 // CHECK:   cir.store %1, %0 : !s16i, !cir.ptr<!s16i>
 void foo(x) short x; {}
 
-// CHECK: cir.func no_proto  @bar(%arg0: !cir.double 
+// CHECK: cir.func no_proto @bar(%arg0: !cir.double 
 // CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]
 // CHECK:   %1 = cir.cast(floating, %arg0 : !cir.double), !cir.float
 // CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>

--- a/clang/test/CIR/CodeGen/member-init-struct.cpp
+++ b/clang/test/CIR/CodeGen/member-init-struct.cpp
@@ -15,7 +15,7 @@ struct C {
   C(void (C::*x)(), int y) : b(), c(y), e(x) {}
 };
 
-// CHECK-LABEL:   cir.global  external @x = #cir.zero : !ty_A
+// CHECK-LABEL:   cir.global external @x = #cir.zero : !ty_A
 A x;
 C a, b(x), c(0, 2);
 

--- a/clang/test/CIR/CodeGen/no-pie.c
+++ b/clang/test/CIR/CodeGen/no-pie.c
@@ -7,5 +7,5 @@ extern int var;
 int get() {
   return var;
 }
-// CIR: cir.global "private"  external dsolocal @var : !s32i {alignment = 4 : i64}
+// CIR: cir.global "private" external dsolocal @var : !s32i {alignment = 4 : i64}
 // LLVM: @var = external dso_local global i32

--- a/clang/test/CIR/CodeGen/paren-list-init.cpp
+++ b/clang/test/CIR/CodeGen/paren-list-init.cpp
@@ -23,7 +23,7 @@ template <int I>
 void make1() {
   Vec v;
   S1((Vec&&) v);
-// CIR: cir.func linkonce_odr  @_Z5make1ILi0EEvv()
+// CIR: cir.func linkonce_odr @_Z5make1ILi0EEvv()
 // CIR:   %[[VEC:.*]] = cir.alloca ![[VecType]], !cir.ptr<![[VecType]]>
 // CIR:   cir.call @_ZN3VecC1Ev(%[[VEC]]) : (!cir.ptr<![[VecType]]>)
 // CIR:   cir.scope {
@@ -35,7 +35,7 @@ void make1() {
 // CIR:   cir.call @_ZN3VecD1Ev(%[[VEC]]) : (!cir.ptr<![[VecType]]>) -> ()
 // CIR:   cir.return
 
-// CIR_EH: cir.func linkonce_odr  @_Z5make1ILi0EEvv()
+// CIR_EH: cir.func linkonce_odr @_Z5make1ILi0EEvv()
 // CIR_EH:  %[[VEC:.*]] = cir.alloca ![[VecType]], !cir.ptr<![[VecType]]>, ["v", init]
 
 // Construct v

--- a/clang/test/CIR/CodeGen/static-vars.cpp
+++ b/clang/test/CIR/CodeGen/static-vars.cpp
@@ -38,7 +38,7 @@ void func2(void) {
   // CHECK-DAG: cir.global "private" internal dsolocal @_ZZ5func2vE1j = #cir.fp<0.000000e+00> : !cir.float
 }
 
-// CHECK-DAG: cir.global  linkonce_odr comdat @_ZZ4testvE1c = #cir.int<0> : !s32i
+// CHECK-DAG: cir.global linkonce_odr comdat @_ZZ4testvE1c = #cir.int<0> : !s32i
 
 // LLVM-DAG: $_ZZ4testvE1c = comdat any
 // LLVM-DAG: @_ZZ4testvE1c = linkonce_odr global i32 0, comdat, align 4

--- a/clang/test/CIR/CodeGen/stmt-expr.c
+++ b/clang/test/CIR/CodeGen/stmt-expr.c
@@ -4,9 +4,8 @@
 // Yields void.
 void test1() { ({ }); }
 // CHECK: @test1
-//     CHECK: cir.scope {
-// CHECK-NOT:   cir.yield
-//     CHECK: }
+//     CHECK-NEXT: cir.return
+
 
 // Yields an out-of-scope scalar.
 void test2() { ({int x = 3; x; }); }

--- a/clang/test/CIR/CodeGen/stmtexpr-init.c
+++ b/clang/test/CIR/CodeGen/stmtexpr-init.c
@@ -33,11 +33,11 @@ struct outer {
 };
 
 void T2(void) {
-  // CIR-DAG: cir.global "private" constant internal @T2._a = #cir.const_struct<{#cir.int<2> : !s32i, #cir.const_array<[#cir.int<50> : !s32i, #cir.int<60> : !s32i]> : !cir.array<!s32i x 2>}>
+  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a = #cir.const_struct<{#cir.int<2> : !s32i, #cir.const_array<[#cir.int<50> : !s32i, #cir.int<60> : !s32i]> : !cir.array<!s32i x 2>}>
   // LLVM-DAG: internal constant { i32, [2 x i32] } { i32 2, [2 x i32] [i32 50, i32 60] }
   const struct sized_array *A = ARRAY_PTR(50, 60);
 
-  // CIR-DAG: cir.global "private" constant internal @T2._a.1 = #cir.const_struct<{#cir.int<3> : !s32i, #cir.const_array<[#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.int<30> : !s32i]> : !cir.array<!s32i x 3>}>
+  // CIR-DAG: cir.global "private" constant internal dsolocal @T2._a.1 = #cir.const_struct<{#cir.int<3> : !s32i, #cir.const_array<[#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.int<30> : !s32i]> : !cir.array<!s32i x 3>}>
   // LLVM-DAG: internal constant { i32, [3 x i32] } { i32 3, [3 x i32] [i32 10, i32 20, i32 30] }
   struct outer X = {ARRAY_PTR(10, 20, 30)};
 

--- a/clang/test/CIR/CodeGen/temporaries.cpp
+++ b/clang/test/CIR/CodeGen/temporaries.cpp
@@ -14,9 +14,9 @@ void f() {
   !E();
 }
 
-//      CIR: cir.func private  @_ZN1EC1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
-// CIR-NEXT: cir.func private  @_ZN1EntEv(!cir.ptr<!ty_E>) -> !ty_E
-// CIR-NEXT: cir.func private  @_ZN1ED1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
+//      CIR: cir.func private @_ZN1EC1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
+// CIR-NEXT: cir.func private @_ZN1EntEv(!cir.ptr<!ty_E>) -> !ty_E
+// CIR-NEXT: cir.func private @_ZN1ED1Ev(!cir.ptr<!ty_E>) extra(#fn_attr)
 // CIR-NEXT: cir.func @_Z1fv() extra(#fn_attr1) {
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     %[[ONE:[0-9]+]] = cir.alloca !ty_E, !cir.ptr<!ty_E>, ["agg.tmp.ensured"] {alignment = 1 : i64}
@@ -44,8 +44,8 @@ void f() {
 const unsigned int n = 1234;
 const int &r = (const int&)n;
 
-//      CIR: cir.global "private"  constant internal @_ZGR1r_ = #cir.int<1234> : !s32i
-// CIR-NEXT: cir.global  constant external @r = #cir.global_view<@_ZGR1r_> : !cir.ptr<!s32i> {alignment = 8 : i64}
+//      CIR: cir.global "private" constant internal @_ZGR1r_ = #cir.int<1234> : !s32i
+// CIR-NEXT: cir.global constant external @r = #cir.global_view<@_ZGR1r_> : !cir.ptr<!s32i> {alignment = 8 : i64}
 
 //      LLVM: @_ZGR1r_ = internal constant i32 1234, align 4
 // LLVM-NEXT: @r = constant ptr @_ZGR1r_, align 8

--- a/clang/test/CIR/CodeGen/tempref.cpp
+++ b/clang/test/CIR/CodeGen/tempref.cpp
@@ -6,9 +6,9 @@
 struct A { ~A(); };
 A &&a = dynamic_cast<A&&>(A{});
 
-//      CHECK: cir.func private  @_ZN1AD1Ev(!cir.ptr<!ty_A>) extra(#fn_attr)
-// CHECK-NEXT: cir.global  external @a = #cir.ptr<null> : !cir.ptr<!ty_A> {alignment = 8 : i64, ast = #cir.var.decl.ast}
-// CHECK-NEXT: cir.func internal private  @__cxx_global_var_init() {
+//      CHECK: cir.func private @_ZN1AD1Ev(!cir.ptr<!ty_A>) extra(#fn_attr)
+// CHECK-NEXT: cir.global external @a = #cir.ptr<null> : !cir.ptr<!ty_A> {alignment = 8 : i64, ast = #cir.var.decl.ast}
+// CHECK-NEXT: cir.func internal private @__cxx_global_var_init() {
 // CHECK-NEXT:   cir.scope {
 // CHECK-NEXT:     %[[SEVEN:[0-9]+]] = cir.get_global @a : !cir.ptr<!cir.ptr<!ty_A>>
 // CHECK-NEXT:     %[[EIGHT:[0-9]+]] = cir.get_global @_ZGR1a_ : !cir.ptr<!ty_A>
@@ -16,7 +16,7 @@ A &&a = dynamic_cast<A&&>(A{});
 // CHECK-NEXT:   }
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
-// CHECK-NEXT: cir.func private  @_GLOBAL__sub_I_tempref.cpp() {
+// CHECK-NEXT: cir.func private @_GLOBAL__sub_I_tempref.cpp() {
 // CHECK-NEXT:   cir.call @__cxx_global_var_init() : () -> ()
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }

--- a/clang/test/CIR/CodeGen/unary-deref.cpp
+++ b/clang/test/CIR/CodeGen/unary-deref.cpp
@@ -10,7 +10,7 @@ void foo() {
   (void)p.read();
 }
 
-// CHECK:  cir.func linkonce_odr  @_ZNK12MyIntPointer4readEv
+// CHECK:  cir.func linkonce_odr @_ZNK12MyIntPointer4readEv
 // CHECK:  %2 = cir.load %0
 // CHECK:  %3 = cir.get_member %2[0] {name = "ptr"}
 // CHECK:  %4 = cir.load deref %3 : !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGen/union-init.c
+++ b/clang/test/CIR/CodeGen/union-init.c
@@ -34,7 +34,7 @@ void foo(int x) {
 // CHECK:  cir.return
 
 union { int i; float f; } u = { };
-// CHECK: cir.global  external @u = #cir.zero : ![[TY_u]]
+// CHECK: cir.global external @u = #cir.zero : ![[TY_u]]
 
 unsigned is_little(void) {
   const union {

--- a/clang/test/CIR/CodeGen/visibility-attribute.c
+++ b/clang/test/CIR/CodeGen/visibility-attribute.c
@@ -1,5 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s -check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o - | FileCheck %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck %s -input-file=%t.cir -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -fno-clangir-call-conv-lowering %s -o %t.ll
+// RUN: FileCheck %s -input-file=%t.ll -check-prefix=LLVM
 
 extern int glob_default;
 // CIR: cir.global "private" external @glob_default : !s32i

--- a/clang/test/CIR/IR/annotations.cir
+++ b/clang/test/CIR/IR/annotations.cir
@@ -28,7 +28,7 @@ cir.func @bar() attributes {annotations = [#cir.annotation<name = "noargfunc", a
 // CHECK-SAME: ["bar", #cir.annotation<name = "noargfunc", args = []>],
 // CHECK-SAME: ["bar", #cir.annotation<name = "withargfunc", args = ["os", 23 : i32]>],
 // CHECK-SAME: ["_Z1fv", #cir.annotation<name = "tile", args = []>]]>}
-// CHECK: cir.global  external @a = #cir.int<0> : !s32i
+// CHECK: cir.global external @a = #cir.int<0> : !s32i
 // CHECK-SAME: [#cir.annotation<name = "testanno", args = ["21", 12 : i32]>]
 // CHECK: cir.func @foo()
 // CHECK-SAME: [#cir.annotation<name = "withargfunc", args = ["os", 22 : i32]>]

--- a/clang/test/CIR/IR/invalid-annotations.cir
+++ b/clang/test/CIR/IR/invalid-annotations.cir
@@ -4,7 +4,7 @@
 
 // expected-error @below {{invalid kind of attribute specified}}
 // expected-error @below {{failed to parse AnnotationAttr parameter 'name' which is to be a `mlir::StringAttr`}}
-cir.global  external @a = #cir.ptr<null> : !cir.ptr<!cir.double> [#cir.annotation<name = 18, args = ["21", 12 : i32]>]
+cir.global external @a = #cir.ptr<null> : !cir.ptr<!cir.double> [#cir.annotation<name = 18, args = ["21", 12 : i32]>]
 
 // -----
 

--- a/clang/test/CIR/Lowering/brcond.cir
+++ b/clang/test/CIR/Lowering/brcond.cir
@@ -3,7 +3,7 @@
 
 !s32i = !cir.int<s, 32>
 #fn_attr = #cir<extra({inline = #cir.inline<no>, nothrow = #cir.nothrow, optnone = #cir.optnone})>
-module { cir.func no_proto  @test() -> !cir.bool extra(#fn_attr) {
+module { cir.func no_proto @test() -> !cir.bool extra(#fn_attr) {
     %0 = cir.const #cir.int<0> : !s32i 
     %1 = cir.cast(int_to_bool, %0 : !s32i), !cir.bool 
     cir.br ^bb1 

--- a/clang/test/CIR/Lowering/if.cir
+++ b/clang/test/CIR/Lowering/if.cir
@@ -18,12 +18,12 @@ module {
 //      MLIR:   llvm.func @foo(%arg0: i32) -> i32
 // MLIR-NEXT:     %0 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     %1 = llvm.icmp "ne" %arg0, %0 : i32
-// MLIR-NEXT:     llvm.cond_br %1, ^bb2, ^bb1
+// MLIR-NEXT:     llvm.cond_br %1, ^bb1, ^bb2
 // MLIR-NEXT:   ^bb1:  // pred: ^bb0
-// MLIR-NEXT:     %2 = llvm.mlir.constant(0 : i32) : i32
+// MLIR-NEXT:     %2 = llvm.mlir.constant(1 : i32) : i32
 // MLIR-NEXT:     llvm.return %2 : i32
 // MLIR-NEXT:   ^bb2:  // pred: ^bb0
-// MLIR-NEXT:     %3 = llvm.mlir.constant(1 : i32) : i32
+// MLIR-NEXT:     %3 = llvm.mlir.constant(0 : i32) : i32
 // MLIR-NEXT:     llvm.return %3 : i32
 // MLIR-NEXT:   ^bb3:  // no predecessors
 // MLIR-NEXT:     llvm.return %arg0 : i32
@@ -31,13 +31,13 @@ module {
 
 //       LLVM: define i32 @foo(i32 %0)
 //  LLVM-NEXT:   %2 = icmp ne i32 %0, 0
-//  LLVM-NEXT:   br i1 %2, label %4, label %3
+//  LLVM-NEXT:   br i1 %2, label %3, label %4
 // LLVM-EMPTY:
 //  LLVM-NEXT: 3:
-//  LLVM-NEXT:   ret i32 0
+//  LLVM-NEXT:   ret i32 1
 // LLVM-EMPTY:
 //  LLVM-NEXT: 4:
-//  LLVM-NEXT:   ret i32 1
+//  LLVM-NEXT:   ret i32 0
 // LLVM-EMPTY:
 //  LLVM-NEXT: 5:
 //  LLVM-NEXT:   ret i32 %0
@@ -85,12 +85,12 @@ module {
     %4 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
     // MLIR: llvm.cond_br {{%.*}}, ^[[T:.*]], ^[[F:.*]]
     cir.if %4 {
-    } else {
-    }
-    // MLIR-NEXT: ^[[F]]:
-    // MLIR-NEXT:   llvm.br ^[[PHI:.*]]
     // MLIR-NEXT: ^[[T]]:
+    // MLIR-NEXT:   llvm.br ^[[PHI:.*]]
+    } else {
+    // MLIR-NEXT: ^[[F]]:
     // MLIR-NEXT:   llvm.br ^[[PHI]]
+    }
     // MLIR-NEXT: ^[[PHI]]:
     // MLIR-NEXT:   llvm.return
     cir.return %arg0 : !s32i

--- a/clang/test/CIR/Lowering/if.cir
+++ b/clang/test/CIR/Lowering/if.cir
@@ -62,4 +62,38 @@ module {
   // MLIR-NEXT: ^bb2:  // pred: ^bb0
   // MLIR-NEXT:   llvm.return %arg0 : i32
   // MLIR-NEXT: }
+
+  // Verify empty if clause is properly lowered to empty block
+  cir.func @emptyIfClause(%arg0: !s32i) -> !s32i {
+    // MLIR-LABEL: llvm.func @emptyIfClause
+    %4 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
+    // MLIR: llvm.cond_br {{%.*}}, ^[[T:.*]], ^[[PHI:.*]]
+    cir.if %4 {
+      // MLIR-NEXT: ^[[T]]:
+      // MLIR-NEXT:   llvm.br ^[[PHI]]
+    }
+    // MLIR-NEXT: ^[[PHI]]:
+    // MLIR-NEXT:   llvm.return
+    cir.return %arg0 : !s32i
+  }
+
+  // Verify empty if-else clauses are properly lowered to empty blocks
+  // TODO: Fix reversed order of blocks in the test once Issue clangir/#1094 is
+  // addressed
+  cir.func @emptyIfElseClause(%arg0: !s32i) -> !s32i {
+    // MLIR-LABEL: llvm.func @emptyIfElseClause
+    %4 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
+    // MLIR: llvm.cond_br {{%.*}}, ^[[T:.*]], ^[[F:.*]]
+    cir.if %4 {
+    } else {
+    }
+    // MLIR-NEXT: ^[[F]]:
+    // MLIR-NEXT:   llvm.br ^[[PHI:.*]]
+    // MLIR-NEXT: ^[[T]]:
+    // MLIR-NEXT:   llvm.br ^[[PHI]]
+    // MLIR-NEXT: ^[[PHI]]:
+    // MLIR-NEXT:   llvm.return
+    cir.return %arg0 : !s32i
+  }
+
 }

--- a/clang/test/CIR/Lowering/store-memcpy.cpp
+++ b/clang/test/CIR/Lowering/store-memcpy.cpp
@@ -5,7 +5,7 @@
 void foo() {
   char s1[] = "Hello";
 }
-// AFTER-DAG:  cir.global "private"  constant cir_private @__const._Z3foov.s1 = #cir.const_array<"Hello\00" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6>
+// AFTER-DAG:  cir.global "private" constant cir_private @__const._Z3foov.s1 = #cir.const_array<"Hello\00" : !cir.array<!s8i x 6>> : !cir.array<!s8i x 6>
 // AFTER: @_Z3foov
 // AFTER:    %[[S1:.*]] = cir.alloca !cir.array<!s8i x 6>, !cir.ptr<!cir.array<!s8i x 6>>, ["s1"]
 // AFTER:    %[[HELLO:.*]] = cir.get_global @__const._Z3foov.s1 : !cir.ptr<!cir.array<!s8i x 6>>

--- a/clang/test/CIR/Transforms/if.cir
+++ b/clang/test/CIR/Transforms/if.cir
@@ -16,12 +16,12 @@ module {
   }
 //      CHECK: cir.func @foo(%arg0: !s32i) -> !s32i {
 // CHECK-NEXT:   %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
-// CHECK-NEXT:   cir.brcond %0 ^bb2, ^bb1
+// CHECK-NEXT:   cir.brcond %0 ^bb1, ^bb2
 // CHECK-NEXT: ^bb1:  // pred: ^bb0
-// CHECK-NEXT:   %1 = cir.const #cir.int<0> : !s32i
+// CHECK-NEXT:   %1 = cir.const #cir.int<1> : !s32i
 // CHECK-NEXT:   cir.return %1 : !s32i
 // CHECK-NEXT: ^bb2:  // pred: ^bb0
-// CHECK-NEXT:   %2 = cir.const #cir.int<1> : !s32i
+// CHECK-NEXT:   %2 = cir.const #cir.int<0> : !s32i
 // CHECK-NEXT:   cir.return %2 : !s32i
 // CHECK-NEXT: ^bb3:  // no predecessors
 // CHECK-NEXT:   cir.return %arg0 : !s32i

--- a/clang/test/CIR/Transforms/mem2reg.c
+++ b/clang/test/CIR/Transforms/mem2reg.c
@@ -1,18 +1,18 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir 
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=BEFORE
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fclangir-mem2reg %s -o %t.cir 
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -fclangir-mem2reg %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=MEM2REG
 
 int return_42() {
   int y = 42;
-  return y;  
+  return y;
 }
 
 // BEFORE: cir.func {{.*@return_42}}
 // BEFORE:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // BEFORE:   %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init] {alignment = 4 : i64}
 // BEFORE:   %2 = cir.const #cir.int<42> : !s32i
-// BEFORE:   cir.store %2, %1 : !s32i, !cir.ptr<!s32i> 
+// BEFORE:   cir.store %2, %1 : !s32i, !cir.ptr<!s32i>
 // BEFORE:   %3 = cir.load %1 : !cir.ptr<!s32i>, !s32i
 // BEFORE:   cir.store %3, %0 : !s32i, !cir.ptr<!s32i>
 // BEFORE:   %4 = cir.load %0 : !cir.ptr<!s32i>, !s32i
@@ -63,7 +63,7 @@ void alloca_in_loop(int* ar, int n) {
 // BEFORE:        cir.yield
 // BEFORE:      }
 // BEFORE:    }
-// BEFORE:    cir.return  
+// BEFORE:    cir.return
 
 // MEM2REG:  cir.func {{.*@alloca_in_loop}}
 // MEM2REG:    cir.br ^bb1
@@ -152,13 +152,13 @@ int alloca_in_ifelse(int x) {
 // MEM2REG:    %1 = cir.const #cir.int<42> : !s32i
 // MEM2REG:    %2 = cir.cmp(gt, %arg0, %1) : !s32i, !s32i
 // MEM2REG:    %3 = cir.cast(int_to_bool, %2 : !s32i), !cir.bool
-// MEM2REG:    cir.brcond %3 ^bb3, ^bb2
+// MEM2REG:    cir.brcond %3 ^bb2, ^bb3
 // MEM2REG:  ^bb2:  // pred: ^bb1
-// MEM2REG:    %4 = cir.const #cir.int<3> : !s32i
+// MEM2REG:    %4 = cir.const #cir.int<2> : !s32i
 // MEM2REG:    %5 = cir.binop(mul, %arg0, %4) nsw : !s32i
 // MEM2REG:    cir.br ^bb4(%5 : !s32i)
 // MEM2REG:  ^bb3:  // pred: ^bb1
-// MEM2REG:    %6 = cir.const #cir.int<2> : !s32i
+// MEM2REG:    %6 = cir.const #cir.int<3> : !s32i
 // MEM2REG:    %7 = cir.binop(mul, %arg0, %6) nsw : !s32i
 // MEM2REG:    cir.br ^bb4(%7 : !s32i)
 // MEM2REG:  ^bb4(%8: !s32i{{.*}}):  // 2 preds: ^bb2, ^bb3
@@ -174,7 +174,7 @@ int alloca_in_ifelse(int x) {
 
 typedef __SIZE_TYPE__ size_t;
 void *alloca(size_t size);
-  
+
 void test_bitcast(size_t n) {
   int *c1 = alloca(n);
 }
@@ -189,7 +189,7 @@ void test_bitcast(size_t n) {
 // BEFORE:    %5 = cir.cast(bitcast, %4 : !cir.ptr<!void>), !cir.ptr<!s32i>
 // BEFORE:    cir.store %5, %1 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // BEFORE:    cir.return
-  
+
 // MEM2REG:  cir.func {{.*@test_bitcast}}
 // MEM2REG:    cir.return
 // MEM2REG:  }


### PR DESCRIPTION
Before the commit, when flattening if/else clauses - the else body came before the "then" body, as opposed to clang's output order.

This commit reverses this and hopefully allows easier comparisson between clang's output and cir's.